### PR TITLE
Fix sharing of Cognito credentials between user sessions

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -83,7 +83,9 @@ const App: React.FC = () => {
             iconName: 'user-profile',
             onItemClick: (event) => {
               if (event.detail.id === 'signout') {
+                const CREDENTIALS_KEY = 'northstar.sigv4fetch.session';
                 getAuthenticatedUser && getAuthenticatedUser()?.signOut();
+                window.sessionStorage.removeItem(CREDENTIALS_KEY);
                 window.location.href = '/';
               }
             },

--- a/frontend/src/providers/ApiProvider.tsx
+++ b/frontend/src/providers/ApiProvider.tsx
@@ -12,7 +12,9 @@ import { Configuration, DefaultApi, DefaultApiClientProvider } from '../react-qu
 
 export const useApiClient = () => {
   const runtimeConfig = useRuntimeConfig();
-  const client = useSigv4Client('execute-api', true);
+
+  // Accept Cognito token caching; remove credentials on user logout.
+  const client = useSigv4Client('execute-api', false);
 
   return useMemo(
     () =>

--- a/frontend/src/providers/ApiProvider.tsx
+++ b/frontend/src/providers/ApiProvider.tsx
@@ -12,7 +12,7 @@ import { Configuration, DefaultApi, DefaultApiClientProvider } from '../react-qu
 
 export const useApiClient = () => {
   const runtimeConfig = useRuntimeConfig();
-  const client = useSigv4Client();
+  const client = useSigv4Client('execute-api', true);
 
   return useMemo(
     () =>


### PR DESCRIPTION
The bug: if user A logs out and then user B logs in during the same Chrome session, API requests will continue to use user A's user ID. 

This PR keeps caching enabled but removes AWS Northstar-established credentials from window.sessionStorage on signout. 